### PR TITLE
Prevent tampering with amount.

### DIFF
--- a/src/Pronamic.php
+++ b/src/Pronamic.php
@@ -118,6 +118,8 @@ class Pronamic {
 						$options[ $after ][] = $labels[ $key ];
 					}
 
+					$valid_value = empty( $options ) ? $value : null;
+
 					// Search for value in options.
 					foreach ( $options as $after => $labels ) {
 						if ( false !== \array_search( $value, $labels, true ) ) {
@@ -126,18 +128,28 @@ class Pronamic {
 								$free_text_name = sprintf( '%s_free_text', $tag->name );
 
 								if ( \array_key_exists( $free_text_name, $_POST ) ) {
-									$value = trim( \sanitize_text_field( \wp_unslash( $_POST[ $free_text_name ] ) ) );
+									$valid_value = trim( \sanitize_text_field( \wp_unslash( $_POST[ $free_text_name ] ) ) );
 								}
 
 								break;
 							}
 
 							// Set 'after value' as value.
-							$value = $after;
+							$valid_value = $after;
 
 							break;
 						}
+
+						if ( $after === $value ) {
+							$valid_value = $value;
+						}
 					}
+
+					if ( null === $valid_value ) {
+						throw new \Exception( sprintf( __( 'Unable to process unexpected submission value `%s`.', 'pronamic_ideal' ), $value ) );
+					}
+
+					$value = $valid_value;
 				}
 
 				// Parse value.


### PR DESCRIPTION
From customer:

> I see that it is possible to adjust the amount (pronamic_pay_amount) via DevTools. This amount is then visible at Mollie's checkout. Wouldn't it be better to get the value for `pronamic_pay_amount` from the raw `post_content` of CF7? That way you can get the amount from the original field shortcode and pass that amount on to Mollie.

@LeoOosterloo asks in https://github.com/pronamic/pronamic-pay-with-mollie-for-contact-form-7/issues/14 if we can do something about this.

_Internal Help Scout ticket: https://secure.helpscout.net/conversation/2325939497/26014/_

- https://github.com/pronamic/wp-pronamic-pay-contact-form-7/issues/12
